### PR TITLE
Allow overriding with `debug`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ export class Scorm {
         this.version = config.version;
         this.handleExitMode = config.handleExitMode || true;
         this.handleCompletionStatus = config.handleCompletionStatus || true;
-        this.isDebugActive = config.debug || true;
+        this.isDebugActive = config.debug === undefined ? !!config.debug : true;
     }
 
     initialize () {


### PR DESCRIPTION
Right now `debug` doesn't have an effect no matter how you set it. I'm assuming you want the default to be `true` but overridable with `debug: false`. I'd prefer it the other way but I'm submitting this in the spirit of the existing behavior. Happy to change it up, or not. Thanks for the library, works well!
